### PR TITLE
Change views config to work with v2

### DIFF
--- a/app/config/views.yml
+++ b/app/config/views.yml
@@ -1,6 +1,6 @@
 ezpublish:
     system:
-        default:
+        site_group:
             pagelayout: "pagelayout.html.twig"
             user:
                 layout: "pagelayout.html.twig"


### PR DESCRIPTION
Updates view config tu use `site_group` instead of `default`, as overriding default in v2 prohibits access to the Back Office (see https://jira.ez.no/browse/EZP-28506)