### PR TITLE
Fixed paths and quotations consistency

### DIFF
--- a/app/config/layouts.yml
+++ b/app/config/layouts.yml
@@ -4,8 +4,8 @@ ezplatform_page_fieldtype:
             identifier: sidebar
             name: Right sidebar
             description: Main section with sidebar on the right
-            thumbnail: assets/images/layouts/sidebar.png
-            template: layouts/sidebar.html.twig
+            thumbnail: '/assets/images/layouts/sidebar.png'
+            template: 'layouts/sidebar.html.twig'
             zones:
                 first:
                     name: First zone
@@ -15,7 +15,7 @@ ezplatform_page_fieldtype:
         contentlist:
             views:
                 default:
-                    template: blocks/contentlist/default.html.twig
+                    template: 'blocks/contentlist/default.html.twig'
                     name: Content List
         schedule:
             views:
@@ -23,15 +23,15 @@ ezplatform_page_fieldtype:
                     template: 'blocks/schedule/featured.html.twig'
                     name: Featured Schedule Block
         random:
-            name: 'Random block'
-            thumbnail: 'assets/images/blocks/random_block.svg'
+            name: Random block
+            thumbnail: '/assets/images/blocks/random_block.svg'
             views:
                 random:
                     template: 'blocks/random/default.html.twig'
-                    name: 'Random Content Block View'
+                    name: Random Content Block View
             attributes:
                 parent:
-                    type: 'embed'
+                    type: embed
                     name: Parent
                     validators:
                         not_blank:


### PR DESCRIPTION
The thumbnail path should not be relative to avoid broken image paths.
Removed quotes for simple strings to keep things consistent.