### PR TITLE
Switch to non-deprecated config page_layout

### DIFF
--- a/config/packages/views.yaml
+++ b/config/packages/views.yaml
@@ -1,7 +1,7 @@
 ezpublish:
     system:
         site:
-            pagelayout: pagelayout.html.twig
+            page_layout: pagelayout.html.twig
             user:
                 layout: "pagelayout.html.twig"
 


### PR DESCRIPTION
According to eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php `pagelayout` option is deprecated in favor of `page_layout`.